### PR TITLE
Added "weight_deltas" which fixes #25 and #3

### DIFF
--- a/Chapter5 - Generalizing Gradient Descent - Learning Multiple Weights at a Time.ipynb
+++ b/Chapter5 - Generalizing Gradient Descent - Learning Multiple Weights at a Time.ipynb
@@ -53,6 +53,7 @@
     "pred = neural_network(input,weights)\n",
     "error = (pred - true) ** 2\n",
     "delta = pred - true\n",
+    "weight_deltas = ele_mul(delta, input)\n",
     "\n",
     "def ele_mul(number,vector):\n",
     "    output = [0,0,0]\n",


### PR DESCRIPTION
In "Chapter 5: Gradient Descent Learning with Multiple Inputs" the variable "weight_deltas" is missing as reported in issue #25 and #3, which has been added.