### PR TITLE
github thinks the python code is raw text instead of code

### DIFF
--- a/Chapter11 - Intro to Word Embeddings - Neural Networks that Understand Language.ipynb
+++ b/Chapter11 - Intro to Word Embeddings - Neural Networks that Understand Language.ipynb
@@ -119,7 +119,7 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "code",
    "metadata": {},
    "source": [
     "import numpy as np\n",


### PR DESCRIPTION
the first example of embeddeds layer has no newlines because it thinks its rawtext
(p.s. book is awesome)