### PR TITLE
bug: CrossEntropyLoss(object) to CrossEntropyLoss(Layer)

### DIFF
--- a/Chapter13 - Intro to Automatic Differentiation - Let's Build A Deep Learning Framework.ipynb
+++ b/Chapter13 - Intro to Automatic Differentiation - Let's Build A Deep Learning Framework.ipynb
@@ -2022,7 +2022,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class CrossEntropyLoss(object):\n",
+    "class CrossEntropyLoss(Layer):\n",
     "    \n",
     "    def __init__(self):\n",
     "        super().__init__()\n",


### PR DESCRIPTION
I believe `object` should be `Layer` in the`CrossEntropyLoss` class definition.