### PR TITLE
Adding calculation of weight delta

### DIFF
--- a/Chapter5 - Generalizing Gradient Descent - Learning Multiple Weights at a Time.ipynb
+++ b/Chapter5 - Generalizing Gradient Descent - Learning Multiple Weights at a Time.ipynb
@@ -66,6 +66,9 @@
     "\n",
     "  \n",
     "\n",
+    "weight_deltas = ele_mul(delta,input)\n"
+    "\n",
+    "\n",
     "alpha = 0.01\n",
     "\n",
     "for i in range(len(weights)):\n",


### PR DESCRIPTION
In the presented calculation, you have set the value of alpha and updating weights with respect to weight deltas. However, the calculation of weight delta based upon vector multiplication of 'pure error' and 'input array' is not utilized in the code.